### PR TITLE
Added search by base address helper function

### DIFF
--- a/base.c
+++ b/base.c
@@ -282,6 +282,46 @@ struct uio_info_t *uio_find_by_uio_num (int uio_num)
 }
 
 /**
+ * find a UIO device by base address in memory map
+ * @param base address of a memory map member
+ * @returns device info or NULL on failure
+ */
+struct uio_info_t *uio_find_by_base_addr (unsigned long base_addr)
+{
+	struct uio_info_t *info = NULL, **list **uio_list;
+	int mapC, mapNum, found = 0;
+	
+	uio_list = uio_find_devices();
+	if (!uio_list)
+		return NULL;
+	
+	for (list = uio_list; *list; list++)
+	{
+		struct uio_info_t *candidate = *list;
+		
+		// get number of maps and go through each checking the base address
+		mapNum = uio_get_maxmap(candidate);
+		
+		for (mapC = 0; mapC < mapNum; mapC++)
+		{
+			if (base_addr == uio_get_mem_addr(candidate, mapC))	
+			{
+				info = candidate;
+				found = 1;
+				break;
+			}
+		}
+		
+		if (found)
+			break;
+	}
+	
+	free (uio_list);
+	
+	return info;
+}
+ 
+/**
  * open a UIO device (try to map to given address)
  * @param info UIO device info stuct
  * @param ptr try to map at ptr

--- a/libuio.h
+++ b/libuio.h
@@ -38,6 +38,7 @@ struct uio_info_t;
 struct uio_info_t **uio_find_devices ();
 struct uio_info_t *uio_find_by_uio_name (char *uio_name);
 struct uio_info_t *uio_find_by_uio_num (int num);
+struct uio_info_t *uio_find_by_base_addr (unsigned long base_addr);
 void uio_setsysfs_point (const char *sysfs_mpoint);
 char *uio_get_name (struct uio_info_t* info);
 char *uio_get_version (struct uio_info_t* info);


### PR DESCRIPTION
Added a helper function that searches the memory map members of each UIO instance based on a given base address and returns the first UIO info structure that has the matching base address.
