### PR TITLE
debian: add libglib2.0-dev & texinfo to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: libuio
 Priority: extra
 Maintainer: Benedikt Spranger <b.spranger@linutronix.de>
-Build-Depends: debhelper (>= 7.0.50~), dh-autoreconf, autotools-dev
+Build-Depends: debhelper (>= 7.0.50~), dh-autoreconf, autotools-dev, libglib2.0-dev, texinfo
 Standards-Version: 3.9.6
 Section: libs
 Vcs-Git: git://git.linutronix.de/projects/libUIO.git


### PR DESCRIPTION
Signed-off-by: Robert Nelson robertcnelson@gmail.com
